### PR TITLE
Improve error handling to avoid masking errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,8 +64,10 @@ class Reactor extends Component {
     }
 
     promise
-      .then((data) => this._setResult(data))
-      .catch((err) => this._handleError(err));
+      .then(
+        (data) => this._setResult(data),
+        (err) => this._handleError(err)
+      );
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Previously any errors inside result render would be masked by chained `.catch`.