### PR TITLE
feat: pass props to loader component, too

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ class Reactor extends Component {
       }
     }
 
-    return createElement(this.props.loader);
+    return createElement(this.props.loader, this._passthroughProps);
   }
 }
 


### PR DESCRIPTION
This allows for using the fallback component both in the loading and the
error state.

Useful in constructs like this:

```js
// @flow

type Props = {image?: {src: string}, children: React.Node}

function Image ({ image, children }: Props) {
  return (
    <div style={{background: image ? `url(${image.src})` : '#333'}}>
    {children}
    </div>
  )
}

async function LoadImage (props: {imageName: string} & Props) {
  const loadedImage = await import('./images/'+props.imageName)
  return <Image {...props} image={loadedImage} />
}

export default asyncReactor(LoadImage, Image, Image)

```